### PR TITLE
simplify istanbul invocation via grunt-mocha-istanbul

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,3 @@
-var exec = require('child_process').exec;
-
-var BIN = './node_modules/.bin/';
-
 module.exports = function(grunt) {
 
 	// Project configuration.
@@ -23,8 +19,15 @@ module.exports = function(grunt) {
 		clean: {
 			src: ['tmp']
 		},
-		istanbul: {
-			src: ['test/**/*_test.js']
+		mocha_istanbul: {
+			coverage: {
+				src: 'test',
+				options: {
+					mask: '**/*_test.js',
+					reportFormats: ['html'],
+					reporter: 'min'
+				}
+			}
 		}
 	});
 
@@ -32,27 +35,10 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-mocha-test');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-clean');
-
-	// Register tasks
-	grunt.registerMultiTask('istanbul', 'generate test coverage report', function() {
-		var done = this.async(),
-			cmd = BIN + 'istanbul cover --report html ' + BIN + '_mocha -- -R min ' +
-				this.filesSrc.reduce(function(p,c) { return (p || '') + ' "' + c + '" '; });
-
-		grunt.log.debug(cmd);
-		exec(cmd, function(err, stdout, stderr) {
-			if (err) { grunt.fail.fatal(err); }
-			if (/No coverage information was collected/.test(stderr)) {
-				grunt.fail.warn('No coverage information was collected. Report not generated.');
-			} else {
-				grunt.log.ok('test coverage report generated to "./coverage/index.html"');
-			}
-			done();
-		});
-	});
+	grunt.loadNpmTasks('grunt-mocha-istanbul');
 
 	grunt.registerTask('test', ['mochaTest', 'clean']);
-	grunt.registerTask('coverage', ['istanbul', 'clean']);
+	grunt.registerTask('coverage', ['mocha_istanbul', 'clean']);
 	grunt.registerTask('default', ['jshint', 'mochaTest', 'clean']);
 
 };

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-mocha-test": "~0.10.2",
-    "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-clean": "~0.5.0",
-    "should": "~3.3.1",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-mocha-istanbul": "~2.0.0",
+    "grunt-mocha-test": "~0.10.2",
     "istanbul": "~0.2.10",
-    "mocha": "~1.19.0"
+    "mocha": "~1.19.0",
+    "should": "~3.3.1"
   },
   "engines": {
     "node": ">=0.10"

--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -1,7 +1,3 @@
-var exec = require('child_process').exec;
-
-var BIN = './node_modules/.bin/';
-
 module.exports = function(grunt) {
 
 	// Project configuration.
@@ -23,8 +19,15 @@ module.exports = function(grunt) {
 		clean: {
 			src: ['tmp']
 		},
-		istanbul: {
-			src: ['test/**/*_test.js']
+		mocha_istanbul: {
+			coverage: {
+				src: 'test',
+				options: {
+					mask: '**/*_test.js',
+					reportFormats: ['html'],
+					reporter: 'min'
+				}
+			}
 		}
 	});
 
@@ -32,25 +35,9 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-mocha-test');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-clean');
+	grunt.loadNpmTasks('grunt-mocha-istanbul');
 
-	// Register tasks
-	grunt.registerMultiTask('istanbul', 'generate test coverage report', function() {
-		var done = this.async(),
-			cmd = BIN + 'istanbul cover --report html ' + BIN + '_mocha -- -R min ' +
-				this.filesSrc.reduce(function(p,c) { return (p || '') + ' "' + c + '" '; });
-
-		grunt.log.debug(cmd);
-		exec(cmd, function(err, stdout, stderr) {
-			if (err) { grunt.fail.fatal(err); }
-			if (/No coverage information was collected/.test(stderr)) {
-				grunt.fail.warn('No coverage information was collected. Report not generated.');
-			} else {
-				grunt.log.ok('test coverage report generated to "./coverage/index.html"');
-			}
-			done();
-		});
-	});
-	grunt.registerTask('coverage', ['istanbul', 'clean']);
+	grunt.registerTask('coverage', ['mocha_istanbul', 'clean']);
 	grunt.registerTask('test', ['mochaTest']);
 	grunt.registerTask('default', ['jshint', 'mochaTest', 'clean']);
 


### PR DESCRIPTION
Of the grunt+istanbul plugins, I found [grunt-mocha-istanbul](https://github.com/pocesar/grunt-mocha-istanbul) to be the easiest to use. It's a lot more "grunt-y" than your solution and adds easy config for other options.

The only part I'm not completely crazy about is the way you have to specify `src` & `mask`. Seems like that could be done better, to provide a glob-style value for `src`.
